### PR TITLE
fix: url to GitHub discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: "DataSanitizer Q&A and Support"
-    url: https://dsccommunity.org/community/contact/
+    url: https://github.com/fslef/DataSanitizer/discussions
     about: "For any questions or to share your thoughts about this powershell module, please visit the GitHub discussion channel."


### PR DESCRIPTION
This pull request updates the `.github/ISSUE_TEMPLATE/config.yml` file to redirect users to the GitHub Discussions page for support and Q&A instead of the previous contact link.